### PR TITLE
Update Gradle & Podspec

### DIFF
--- a/RNPointerInteractions.podspec
+++ b/RNPointerInteractions.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 
 Pod::Spec.new do |s|
-  s.name = 'RNPointerInteractions'
+  s.name = "RNPointerInteractions"
   s.version = package["version"]
   s.summary = package["description"]
   s.license = package["license"]
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
 
   s.swift_version = "5.0"
 
-  s.dependency "React"
+  s.dependency "React-Core"
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath("com.android.tools.build:gradle:4.1.0")
     }
 }
 
@@ -31,6 +31,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation "com.facebook.react:react-native:+"
 }
   

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thefunbots/react-native-pointer-interactions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expose iPad mouse & track pads interactions to React Native",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Hey, thanks for the library!

This PR avoids the following deprecation (I know it's not an Android library, but the eases the build process all the same) & includes the [more specific React-Core dependency](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116).
```
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed in version 5.0 of the Android Gradle plugin.
For more information, see http://d.android.com/r/tools/update-dependency-configurations.html.
```